### PR TITLE
chore: add git lfs tracking

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.keras filter=lfs diff=lfs merge=lfs -text
+*.pt filter=lfs diff=lfs merge=lfs -text
+*.h5 filter=lfs diff=lfs merge=lfs -text
+*.pkl filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
chore: add git lfs trackin
용량이 큰 model 파일, git large storage 에 등록 하게 하기